### PR TITLE
Drop dependency on deprecated pedantic plugin

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,1 +1,10 @@
-include: package:pedantic/analysis_options.yaml
+include: package:lints/recommended.yaml
+
+linter:
+  rules:
+    - always_declare_return_types
+    - prefer_single_quotes
+    - sort_child_properties_last
+    - unawaited_futures
+    - unsafe_html
+    - use_full_hex_values_for_flutter_colors

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,6 @@ dependencies:
   dbus: ^0.6.2
 
 dev_dependencies:
-  pedantic: ^1.9.0
+  lints: ^1.0.1
   test: ^1.16.8
   test_cov: ^1.0.1


### PR DESCRIPTION
Pedantic is deprecated upstream. Drop support and switch to equivalent `lints` package with appropriate configuration to match `pedantic`'s default rule set.
